### PR TITLE
allow passing zlib=True to write_nc to enable compression

### DIFF
--- a/dimarray/io/nc.py
+++ b/dimarray/io/nc.py
@@ -241,13 +241,14 @@ def write_obj(f, obj, *args, **kwargs):
     else:
         raise TypeError("only DimArray or Dataset types allowed, got {}:{}".format(type(obj), obj))
 
-def write_dataset(f, obj, mode='w-', **kwargs):
+def write_dataset(f, obj, mode='w-', zlib=False, **kwargs):
     """ write object to file
     """
     f, close = check_file(f, mode, **kwargs)
     nms = obj.keys()
+        
     for nm in obj:
-        write_variable(f, obj[nm], nm)
+        write_variable(f, obj[nm], nm, zlib=zlib)
 
     # set metadata for the whole dataset
     meta = obj._metadata
@@ -299,7 +300,7 @@ def createVariable(f, name, axes=None, dtype=float, **kwargs):
 
 #def write_attributes(f, obj):
 
-def write_variable(f, obj, name=None, mode='a+', format='NETCDF4', indices=None, axis=0, verbose=False, **kwargs):
+def write_variable(f, obj, name=None, mode='a+', format='NETCDF4', indices=None, axis=0, verbose=False, zlib=False, **kwargs):
     """ save DimArray instance to file
 
     f        : file name or netCDF file handle
@@ -316,7 +317,7 @@ def write_variable(f, obj, name=None, mode='a+', format='NETCDF4', indices=None,
     # create variable if necessary
     if name not in f.variables:
         assert isinstance(obj, DimArray), "a must be a DimArray"
-        v = createVariable(f, name, obj.axes, dtype=obj.dtype)
+        v = createVariable(f, name, obj.axes, dtype=obj.dtype, zlib=zlib)
 
     # or just check dimensions
     else:


### PR DESCRIPTION
I was surprised to see that write_nc created nc4 files of the exact same size of in-memory arrays. Turns out zlib compression is not enabled. With these changes one can call dataset.write_nc(..., zlib=True) to enable compression.

With these change my output files have been reduced from 9.4M to ~120K, which made me breathe easier (I need to create ~50,000 of those).

It's my first pull request so I might have done some things wrong :-)
